### PR TITLE
Add settings storage and portable script

### DIFF
--- a/portable.ps1
+++ b/portable.ps1
@@ -1,0 +1,37 @@
+param(
+    [string]$SettingsPath = Join-Path $PSScriptRoot 'settings.json',
+    [switch]$Uninstall,
+    [string]$DisplayName,
+    [string]$DeviceId,
+    [string]$SunshineConfigPath,
+    [string]$SunshineConfigBackup,
+    [string]$ServiceName,
+    [string]$Version
+)
+
+if ($Uninstall) {
+    if (Test-Path $SettingsPath) {
+        Remove-Item $SettingsPath -Force
+    }
+    return
+}
+
+if (Test-Path $SettingsPath) {
+    try {
+        $settings = Get-Content $SettingsPath -Raw | ConvertFrom-Json
+    } catch {
+        $settings = [ordered]@{}
+    }
+} else {
+    $settings = [ordered]@{}
+}
+
+if ($DisplayName) { $settings.displayName = $DisplayName }
+if ($DeviceId) { $settings.deviceId = $DeviceId }
+if ($SunshineConfigPath) { $settings.sunshineConfigPath = $SunshineConfigPath }
+if ($SunshineConfigBackup) { $settings.sunshineConfigBackup = $SunshineConfigBackup }
+if ($ServiceName) { $settings.serviceName = $ServiceName }
+if (-not $settings.installDate) { $settings.installDate = (Get-Date).ToString('o') }
+if ($Version) { $settings.version = $Version }
+
+$settings | ConvertTo-Json -Depth 3 | Set-Content $SettingsPath -Encoding UTF8

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,9 @@
+{
+  "displayName": "",
+  "deviceId": "",
+  "sunshineConfigPath": "",
+  "sunshineConfigBackup": "",
+  "serviceName": "",
+  "installDate": "",
+  "version": ""
+}


### PR DESCRIPTION
## Summary
- Store display info and sunshine config details in `settings.json`
- Update PowerShell script to manage settings and clean up on uninstall

## Testing
- `pwsh -NoProfile -Command "$PSVersionTable"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68b3599830508324920a52462c29bb8c