### PR TITLE
Add logging and PowerShell lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install PSScriptAnalyzer
+        run: |
+          pwsh -NoLogo -NoProfile -Command "Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser"
+      - name: Lint PowerShell scripts
+        run: |
+          pwsh -NoLogo -NoProfile -Command "Invoke-ScriptAnalyzer -Path . -Recurse -EnableExit"
+      - name: Check PowerShell formatting
+        run: |
+          pwsh -NoLogo -NoProfile -Command "Get-ChildItem -Recurse -Filter *.ps1 | ForEach-Object { $content = Get-Content $_.FullName -Raw; $formatted = Invoke-Formatter -ScriptDefinition $content; if ($content -ne $formatted) { Write-Error 'Formatting issue in ' + $_.FullName; exit 1 } }"

--- a/auto_display.ps1
+++ b/auto_display.ps1
@@ -1,0 +1,29 @@
+param(
+    [Parameter(Mandatory)][ValidateSet('install','uninstall')]
+    [string]$Action
+)
+
+$logDir = Join-Path $PSScriptRoot 'logs'
+if (-not (Test-Path $logDir)) {
+    New-Item -ItemType Directory -Path $logDir | Out-Null
+}
+
+$timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$logPath = Join-Path $logDir "auto_display-$Action-$timestamp.log"
+Start-Transcript -Path $logPath -Append | Out-Null
+
+try {
+    switch ($Action) {
+        'install' {
+            Write-Output 'Performing auto_display install...'
+            # TODO: Add install logic
+        }
+        'uninstall' {
+            Write-Output 'Performing auto_display uninstall...'
+            # TODO: Add uninstall logic
+        }
+    }
+}
+finally {
+    Stop-Transcript | Out-Null
+}

--- a/portable.ps1
+++ b/portable.ps1
@@ -1,0 +1,29 @@
+param(
+    [Parameter(Mandatory)][ValidateSet('install','uninstall')]
+    [string]$Action
+)
+
+$logDir = Join-Path $PSScriptRoot 'logs'
+if (-not (Test-Path $logDir)) {
+    New-Item -ItemType Directory -Path $logDir | Out-Null
+}
+
+$timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$logPath = Join-Path $logDir "portable-$Action-$timestamp.log"
+Start-Transcript -Path $logPath -Append | Out-Null
+
+try {
+    switch ($Action) {
+        'install' {
+            Write-Output 'Performing portable install...'
+            # TODO: Add install logic
+        }
+        'uninstall' {
+            Write-Output 'Performing portable uninstall...'
+            # TODO: Add uninstall logic
+        }
+    }
+}
+finally {
+    Stop-Transcript | Out-Null
+}


### PR DESCRIPTION
## Summary
- add logging with Start-Transcript in portable and auto_display scripts
- add GitHub Actions workflow for PowerShell linting and formatting

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-ScriptAnalyzer -Path . -Recurse -EnableExit"` *(fails: The term 'Invoke-ScriptAnalyzer' is not recognized)*
- `pwsh -NoLogo -NoProfile -Command 'Get-ChildItem -Recurse -Filter *.ps1 | ForEach-Object { $content = Get-Content $_.FullName -Raw; $formatted = Invoke-Formatter -ScriptDefinition $content; if ($content -ne $formatted) { Write-Error "Formatting issue in $($_.FullName)"; exit 1 } }'` *(fails: The term 'Invoke-Formatter' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68b3599964c883248d80b37b7640d8cb