### PR TITLE
Handle default service name

### DIFF
--- a/portable.ps1
+++ b/portable.ps1
@@ -54,6 +54,9 @@ function Get-Settings {
     if (Test-Path $Path) {
         try {
             $settings = Get-Content $Path -Raw | ConvertFrom-Json
+            if ([string]::IsNullOrWhiteSpace($settings.serviceName)) {
+                $settings.serviceName = 'SunshineService'
+            }
             return $settings
         } catch {
             Write-Warning "Failed to load settings from $Path"

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ The script automatically reads client resolution from Sunshine environment varia
 
 ## Files Created
 
-- `settings.json` - Stores installation info
+- `settings.json` - Stores installation info (pre-filled with default `SunshineService` name)
 - `logs/` - Contains debug logs (created on first run)
 
 ## Notes

--- a/settings.json
+++ b/settings.json
@@ -3,7 +3,7 @@
   "deviceId": "",
   "sunshineConfigPath": "",
   "sunshineConfigBackup": "",
-  "serviceName": "",
+  "serviceName": "SunshineService",
   "installDate": "",
-  "version": ""
+  "version": "1.0.0"
 }


### PR DESCRIPTION
## Summary
- Default the `serviceName` field when loading settings to prevent Get-Service errors
- Pre-fill `settings.json` with `SunshineService`
- Document default service name in README

## Testing
- `pwsh -NoLogo -NoProfile -Command "Get-Host"` *(fails: command not found)*
- `sudo apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b3636c116c8324bacd238179934012